### PR TITLE
feat: add wrapper for Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ go get github.com/cappuccinotm/slogx
   - `slogm.ContextWithRequestID(ctx context.Context, requestID string) context.Context` - adds a request ID to the context.
 - `slogm.StacktraceOnError()` - adds a stacktrace to the log entry if log entry's level is ERROR.
 - `slogm.TrimAttrs(limit int)` - trims the length of the attributes to `limit`.
+- `slogx.ApplyHandler` - wraps slog.Handler as Middleware
 - `slogm.MaskSecrets(replacement string)` - masks secrets in logs, which are stored in the context
   - `slogm.AddSecrets(ctx context.Context, secret ...string) context.Context` - adds a secret value to the context
     - Note: secrets are stored in the context as a pointer to the container object, guarded by a mutex. Child context 

--- a/slogx.go
+++ b/slogx.go
@@ -62,7 +62,10 @@ func Attrs(rec slog.Record) []slog.Attr {
 func HandlerAsMiddleware(handler slog.Handler) Middleware {
 	return func(next HandleFunc) HandleFunc {
 		return func(ctx context.Context, rec slog.Record) error {
-			_ = handler.Handle(ctx, rec)
+			err := handler.Handle(ctx, rec)
+			if err != nil {
+				return err
+			}
 
 			return next(ctx, rec)
 		}

--- a/slogx.go
+++ b/slogx.go
@@ -58,6 +58,28 @@ func Attrs(rec slog.Record) []slog.Attr {
 	return attrs
 }
 
+// HandleFuncAsMiddleware wrap HandleFunc as Middleware
+func HandleFuncAsMiddleware(handler HandleFunc) Middleware {
+	return func(next HandleFunc) HandleFunc {
+		return func(ctx context.Context, rec slog.Record) error {
+			_ = handler(ctx, rec)
+
+			return next(ctx, rec)
+		}
+	}
+}
+
+// HandlerAsMiddleware wrap slog.Handler as Middleware
+func HandlerAsMiddleware(handler slog.Handler) Middleware {
+	return func(next HandleFunc) HandleFunc {
+		return func(ctx context.Context, rec slog.Record) error {
+			_ = handler.Handle(ctx, rec)
+
+			return next(ctx, rec)
+		}
+	}
+}
+
 // NopHandler returns a slog.Handler, that does nothing.
 func NopHandler() slog.Handler { return nopHandler{} }
 

--- a/slogx.go
+++ b/slogx.go
@@ -58,17 +58,6 @@ func Attrs(rec slog.Record) []slog.Attr {
 	return attrs
 }
 
-// HandleFuncAsMiddleware wrap HandleFunc as Middleware
-func HandleFuncAsMiddleware(handler HandleFunc) Middleware {
-	return func(next HandleFunc) HandleFunc {
-		return func(ctx context.Context, rec slog.Record) error {
-			_ = handler(ctx, rec)
-
-			return next(ctx, rec)
-		}
-	}
-}
-
 // HandlerAsMiddleware wrap slog.Handler as Middleware
 func HandlerAsMiddleware(handler slog.Handler) Middleware {
 	return func(next HandleFunc) HandleFunc {

--- a/slogx.go
+++ b/slogx.go
@@ -58,8 +58,8 @@ func Attrs(rec slog.Record) []slog.Attr {
 	return attrs
 }
 
-// HandlerAsMiddleware wrap slog.Handler as Middleware
-func HandlerAsMiddleware(handler slog.Handler) Middleware {
+// ApplyHandler wraps slog.Handler as Middleware.
+func ApplyHandler(handler slog.Handler) Middleware {
 	return func(next HandleFunc) HandleFunc {
 		return func(ctx context.Context, rec slog.Record) error {
 			err := handler.Handle(ctx, rec)

--- a/slogx_test.go
+++ b/slogx_test.go
@@ -1,11 +1,15 @@
 package slogx
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cappuccinotm/slogx/slogt"
 )
 
 func TestError(t *testing.T) {
@@ -58,5 +62,33 @@ func TestAttrs(t *testing.T) {
 			slog.String("a", "1"),
 			slog.String("b", "2"),
 		}, attrs)
+	})
+}
+
+func TestApplyHandler(t *testing.T) {
+	t.Run("error when handler failed", func(t *testing.T) {
+		mw := ApplyHandler(slogt.HandlerFunc(func(ctx context.Context, rec slog.Record) error {
+			return errors.New("handler failed")
+		}))
+
+		err := mw(func(ctx context.Context, record slog.Record) error {
+			return nil
+		})(context.Background(), slog.Record{})
+		require.Error(t, errors.New("handler failed"), err)
+	})
+
+	t.Run("run next middleware", func(t *testing.T) {
+		mw := ApplyHandler(slogt.HandlerFunc(func(ctx context.Context, rec slog.Record) error {
+			return nil
+		}))
+
+		called := false
+
+		err := mw(func(ctx context.Context, record slog.Record) error {
+			called = true
+			return nil
+		})(context.Background(), slog.Record{})
+		require.NoError(t, err)
+		assert.True(t, called, "next middleware must be called")
 	})
 }


### PR DESCRIPTION
This Pull Request adds wrapper from `slog.Handler` to `slogx.Middleware`

This will allow you to easy connect other popular extensions to slog e.g. [slog-sentry](https://github.com/samber/slog-sentry), [slog-nats](https://github.com/samber/slog-nats) and others that provide the `slog.Handler` interface.

Usage example:

```
package main

import (
	"os"

	slognats "github.com/samber/slog-nats"
	"github.com/cappuccinotm/slogx"
	"github.com/cappuccinotm/slogx/slogm"
	"log/slog"
)

func main() {
	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
		AddSource: true,
		Level:     slog.LevelInfo,
	})

	logger := slog.New(slogx.Accumulator(slogx.NewChain(h,
		slogm.RequestID(),
		// ...
		slogx.HandlerAsMiddleware(slognats.Option{Level: slog.LevelDebug, EncodedConnection: ec, Sub}.NewNATSHandler()),
	)))

	logger.Info("some message")
}
```

This will allow you not to connect additional libraries like [slog-multi](https://github.com/samber/slog-multi) unless absolutely necessary.